### PR TITLE
Raise exception on socket disconnect

### DIFF
--- a/pynats/client.py
+++ b/pynats/client.py
@@ -272,6 +272,9 @@ class NATSClient:
             line = cast(bytes, self._socket_file.readline())
             read.write(line)
 
+            if len(line) == 0:
+                raise ConnectionResetError(self)
+
             if size is not None:
                 if read.tell() == size + len(_CRLF_):
                     break

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -179,3 +179,15 @@ def test_request_timeout(nats_url):
     with NATSClient(nats_url, socket_timeout=2) as client:
         with pytest.raises(socket.timeout):
             client.request("test-subject")
+
+
+def test_exception_on_disconnect(nats_url):
+    with NATSClient(nats_url, socket_timeout=2) as client:
+        client.subscribe(
+            "test-subject", callback=lambda x: x, queue="test-queue", max_messages=2
+        )
+
+        client._socket_file.readline = lambda: b""
+
+        with pytest.raises(ConnectionResetError):
+            client.wait()


### PR DESCRIPTION
This MR provides control over disconnected socket situation: by default `readline` from disconnected socket returns empty string, and NATS subscriber falls in endless loop with eating 100% CPU resource.