### PR TITLE
Support TLS

### DIFF
--- a/pynats/__init__.py
+++ b/pynats/__init__.py
@@ -1,3 +1,23 @@
 from .client import NATSClient, NATSMessage, NATSSubscription
+from .exceptions import (
+    NATSConnectionError,
+    NATSError,
+    NATSInvalidResponse,
+    NATSInvalidSchemeError,
+    NATSTCPConnectionRequiredError,
+    NATSTLSConnectionRequiredError,
+    NATSUnexpectedResponse,
+)
 
-__all__ = ("NATSClient", "NATSMessage", "NATSSubscription")
+__all__ = (
+    "NATSClient",
+    "NATSConnectionError",
+    "NATSError",
+    "NATSInvalidResponse",
+    "NATSInvalidSchemeError",
+    "NATSMessage",
+    "NATSSubscription",
+    "NATSTCPConnectionRequiredError",
+    "NATSTLSConnectionRequiredError",
+    "NATSUnexpectedResponse",
+)

--- a/pynats/exceptions.py
+++ b/pynats/exceptions.py
@@ -1,4 +1,12 @@
-__all__ = ("NATSError", "NATSUnexpectedResponse", "NATSInvalidResponse")
+__all__ = (
+    "NATSConnectionError",
+    "NATSError",
+    "NATSInvalidResponse",
+    "NATSInvalidSchemeError",
+    "NATSTCPConnectionRequiredError",
+    "NATSTLSConnectionRequiredError",
+    "NATSUnexpectedResponse",
+)
 
 
 class NATSError(Exception):
@@ -15,3 +23,27 @@ class NATSInvalidResponse(NATSError):
     def __init__(self, line: bytes, *args, **kwargs) -> None:
         self.line = line
         super().__init__()
+
+
+class NATSConnectionError(NATSError):
+    def __init__(self, line: str, *args, **kwargs) -> None:
+        self.line = line
+        super().__init__()
+
+
+class NATSTCPConnectionRequiredError(NATSConnectionError):
+    def __init__(self, line: str, *args, **kwargs) -> None:
+        self.line = line
+        super().__init__(line, *args, **kwargs)
+
+
+class NATSTLSConnectionRequiredError(NATSConnectionError):
+    def __init__(self, line: str, *args, **kwargs) -> None:
+        self.line = line
+        super().__init__(line, *args, **kwargs)
+
+
+class NATSInvalidSchemeError(NATSConnectionError):
+    def __init__(self, line: str, *args, **kwargs) -> None:
+        self.line = line
+        super().__init__(line, *args, **kwargs)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@ import time
 import msgpack
 import pytest
 
-from pynats import NATSClient
+from pynats import NATSClient, NATSInvalidSchemeError
 
 
 @pytest.fixture
@@ -44,6 +44,20 @@ def test_reconnect(nats_url):
     client.ping()
 
     client.close()
+
+
+def test_tls_connect():
+    client = NATSClient("tls://127.0.0.1:4224", verbose=True)
+
+    client.connect()
+    client.ping()
+
+
+def test_invalid_scheme():
+    client = NATSClient("http://127.0.0.1:4224", verbose=True)
+
+    with pytest.raises(NATSInvalidSchemeError):
+        client.connect()
 
 
 def test_subscribe_unsubscribe(nats_url):


### PR DESCRIPTION
This patchset adds TLS connection capability. To make a TLS
connection, use tls:// schema for a NATS server. You can
specify additional options for NATSClient:

tls_cacert(str):      filepath for CA certificate(default:None)
tls_client_cert(str): filepath for a client certificate(default:None)
tls_client_key(str):  filepath for a client key(default:None)
tls_verify(bool):     Enable TLS verification(default:False)