### PR TITLE
Support TLS (with CI)

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -35,10 +35,14 @@ jobs:
       - run: make install-deps
       - run: make lint
         if: matrix.python-version == 3.8
+      - run: /usr/bin/docker run -d --name nats-tls -p 4224:4224 --entrypoint /usr/local/bin/test-entrypoint.sh -v "$(pwd)/test-entrypoint.sh":"/usr/local/bin/test-entrypoint.sh" nats:2-alpine && sleep 5
       - run: make test
         env:
           NATS_URL: nats://0.0.0.0:${{ job.services.nats.ports['4222'] }}
+          NATS_TLS_URL: tls://0.0.0.0:4224
       - run: make codecov
         if: matrix.python-version == 3.8
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - run: /usr/bin/docker rm --force nats-tls || echo "failed to remove container"
+        if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,11 @@ services:
     image: nats:2
     ports:
       - 4222:4222
+  nats-tls:
+    image: nats:2-alpine
+    ports:
+      - 4224:4224
+    volumes:
+      - ./test-entrypoint.sh:/usr/local/bin/test-entrypoint.sh:ro
+    entrypoint:
+      - /usr/local/bin/test-entrypoint.sh

--- a/pynats/__init__.py
+++ b/pynats/__init__.py
@@ -1,3 +1,23 @@
 from .client import NATSClient, NATSMessage, NATSSubscription
+from .exceptions import (
+    NATSConnectionError,
+    NATSError,
+    NATSInvalidResponse,
+    NATSInvalidSchemeError,
+    NATSTCPConnectionRequiredError,
+    NATSTLSConnectionRequiredError,
+    NATSUnexpectedResponse,
+)
 
-__all__ = ("NATSClient", "NATSMessage", "NATSSubscription")
+__all__ = (
+    "NATSClient",
+    "NATSConnectionError",
+    "NATSError",
+    "NATSInvalidResponse",
+    "NATSInvalidSchemeError",
+    "NATSMessage",
+    "NATSSubscription",
+    "NATSTCPConnectionRequiredError",
+    "NATSTLSConnectionRequiredError",
+    "NATSUnexpectedResponse",
+)

--- a/pynats/client.py
+++ b/pynats/client.py
@@ -2,6 +2,7 @@ import io
 import json
 import re
 import socket
+import ssl
 from dataclasses import dataclass
 from typing import BinaryIO, Callable, Dict, Match, Optional, Pattern, Tuple, Union
 from urllib.parse import urlparse
@@ -10,7 +11,10 @@ import pkg_resources
 
 from pynats.exceptions import (
     NATSInvalidResponse,
+    NATSInvalidSchemeError,
     NATSReadSocketError,
+    NATSTCPConnectionRequiredError,
+    NATSTLSConnectionRequiredError,
     NATSUnexpectedResponse,
 )
 from pynats.nuid import NUID
@@ -95,7 +99,10 @@ class NATSClient:
         name: str = "nats-python",
         verbose: bool = False,
         pedantic: bool = False,
-        ssl_required: bool = False,
+        tls_cacert: Optional[str] = None,
+        tls_client_cert: Optional[str] = None,
+        tls_client_key: Optional[str] = None,
+        tls_verify: bool = False,
         socket_timeout: float = None,
         socket_keepalive: bool = False,
     ) -> None:
@@ -105,9 +112,14 @@ class NATSClient:
             "port": parsed.port,
             "username": parsed.username,
             "password": parsed.password,
+            "scheme": parsed.scheme,
             "name": name,
             "lang": "python",
             "protocol": 0,
+            "tls_cacert": tls_cacert,
+            "tls_client_cert": tls_client_cert,
+            "tls_client_key": tls_client_key,
+            "tls_verify": tls_verify,
             "version": pkg_resources.get_distribution("nats-python").version,
             "verbose": verbose,
             "pedantic": pedantic,
@@ -131,6 +143,41 @@ class NATSClient:
     def __exit__(self, type_, value, traceback) -> None:
         self.close()
 
+    def _connect_tcp(self) -> None:
+        self._send_connect_command()
+        _command, result = self._recv(INFO_RE)
+        server_info = json.loads(result.group(1))
+        if server_info.get("tls_required", False):
+            raise NATSTLSConnectionRequiredError("server enabled TLS connection")
+
+    def _connect_tls(self) -> None:
+        _command, result = self._recv(INFO_RE)
+        server_info = json.loads(result.group(1))
+        if not server_info.get("tls_required", False):
+            raise NATSTCPConnectionRequiredError("server disabled TLS connection")
+
+        ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+        if self._conn_options["tls_verify"]:
+            if self._conn_options["tls_cacert"] is not None:
+                ctx.load_verify_locations(cafile=str(self._conn_options["tls_cacert"]))
+            if (
+                self._conn_options["tls_client_cert"] is not None
+                and self._conn_options["tls_client_key"] is not None
+            ):
+                ctx.load_cert_chain(
+                    certfile=str(self._conn_options["tls_client_cert"]),
+                    keyfile=str(self._conn_options["tls_client_key"]),
+                )
+        else:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+
+        hostname = str(self._conn_options["hostname"])
+        self._socket = ctx.wrap_socket(self._socket, server_hostname=hostname)
+        self._socket_file = self._socket.makefile("rb")
+        self._send_connect_command()
+        self._recv(OK_RE)
+
     def connect(self) -> None:
         sock = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
 
@@ -144,8 +191,13 @@ class NATSClient:
         self._socket_file = sock.makefile("rb")
         self._socket = sock
 
-        self._send_connect_command()
-        self._recv(INFO_RE)
+        scheme = self._conn_options["scheme"]
+        if scheme == "nats":
+            self._connect_tcp()
+        elif scheme == "tls":
+            self._connect_tls()
+        else:
+            raise NATSInvalidSchemeError(f"got unsupported URI scheme: {scheme}")
 
     def close(self) -> None:
         self._socket.shutdown(socket.SHUT_RDWR)

--- a/pynats/client.py
+++ b/pynats/client.py
@@ -144,7 +144,6 @@ class NATSClient:
         self.close()
 
     def _connect_tcp(self) -> None:
-        self._send_connect_command()
         _command, result = self._recv(INFO_RE)
         server_info = json.loads(result.group(1))
         if server_info.get("tls_required", False):
@@ -175,8 +174,6 @@ class NATSClient:
         hostname = str(self._conn_options["hostname"])
         self._socket = ctx.wrap_socket(self._socket, server_hostname=hostname)
         self._socket_file = self._socket.makefile("rb")
-        self._send_connect_command()
-        self._recv(OK_RE)
 
     def connect(self) -> None:
         sock = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
@@ -198,6 +195,9 @@ class NATSClient:
             self._connect_tls()
         else:
             raise NATSInvalidSchemeError(f"got unsupported URI scheme: {scheme}")
+        self._send_connect_command()
+        if self._conn_options["verbose"]:
+            self._recv(OK_RE)
 
     def close(self) -> None:
         self._socket.shutdown(socket.SHUT_RDWR)

--- a/pynats/exceptions.py
+++ b/pynats/exceptions.py
@@ -1,8 +1,12 @@
 __all__ = (
+    "NATSConnectionError",
     "NATSError",
-    "NATSUnexpectedResponse",
     "NATSInvalidResponse",
+    "NATSInvalidSchemeError",
     "NATSReadSocketError",
+    "NATSTCPConnectionRequiredError",
+    "NATSTLSConnectionRequiredError",
+    "NATSUnexpectedResponse",
 )
 
 
@@ -20,6 +24,30 @@ class NATSInvalidResponse(NATSError):
     def __init__(self, line: bytes, *args, **kwargs) -> None:
         self.line = line
         super().__init__()
+
+
+class NATSConnectionError(NATSError):
+    def __init__(self, line: str, *args, **kwargs) -> None:
+        self.line = line
+        super().__init__()
+
+
+class NATSTCPConnectionRequiredError(NATSConnectionError):
+    def __init__(self, line: str, *args, **kwargs) -> None:
+        self.line = line
+        super().__init__(line, *args, **kwargs)
+
+
+class NATSTLSConnectionRequiredError(NATSConnectionError):
+    def __init__(self, line: str, *args, **kwargs) -> None:
+        self.line = line
+        super().__init__(line, *args, **kwargs)
+
+
+class NATSInvalidSchemeError(NATSConnectionError):
+    def __init__(self, line: str, *args, **kwargs) -> None:
+        self.line = line
+        super().__init__(line, *args, **kwargs)
 
 
 class NATSReadSocketError(NATSError):

--- a/test-entrypoint.sh
+++ b/test-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+wget -O mkcert -nc https://github.com/FiloSottile/mkcert/releases/download/v1.4.1/mkcert-v1.4.1-linux-amd64
+chmod +x mkcert
+./mkcert -install
+./mkcert -cert-file server-cert.pem -key-file server-key.pem localhost ::1
+
+exec nats-server --port 4224 --tls --tlscert server-cert.pem --tlskey server-key.pem

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,11 @@ def nats_url():
     return os.environ.get("NATS_URL", "nats://127.0.0.1:4222")
 
 
+@pytest.fixture
+def nats_tls_url():
+    return os.environ.get("NATS_TLS_URL", "tls://127.0.0.1:4224")
+
+
 def test_connect_and_close(nats_url):
     client = NATSClient(nats_url, socket_timeout=2)
 
@@ -47,15 +52,16 @@ def test_reconnect(nats_url):
     client.close()
 
 
-def test_tls_connect():
-    client = NATSClient("tls://127.0.0.1:4224", verbose=True)
+def test_tls_connect(nats_tls_url):
+    client = NATSClient(nats_tls_url, socket_timeout=2)
 
     client.connect()
     client.ping()
+    client.close()
 
 
 def test_invalid_scheme():
-    client = NATSClient("http://127.0.0.1:4224", verbose=True)
+    client = NATSClient("http://127.0.0.1:4224")
 
     with pytest.raises(NATSInvalidSchemeError):
         client.connect()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ import msgpack
 import pytest
 
 from pynats import NATSClient
-from pynats.exceptions import NATSReadSocketError
+from pynats.exceptions import NATSInvalidSchemeError, NATSReadSocketError
 
 
 @pytest.fixture
@@ -45,6 +45,20 @@ def test_reconnect(nats_url):
     client.ping()
 
     client.close()
+
+
+def test_tls_connect():
+    client = NATSClient("tls://127.0.0.1:4224", verbose=True)
+
+    client.connect()
+    client.ping()
+
+
+def test_invalid_scheme():
+    client = NATSClient("http://127.0.0.1:4224", verbose=True)
+
+    with pytest.raises(NATSInvalidSchemeError):
+        client.connect()
 
 
 def test_subscribe_unsubscribe(nats_url):


### PR DESCRIPTION
Based on #7 , adds required CI changes

Original description:
This patchset adds TLS connection capability. To make a TLS
connection, use tls:// schema for a NATS server. You can
specify additional options for NATSClient:

tls_cacert(str): filepath for CA certificate(default:None)
tls_client_cert(str): filepath for a client certificate(default:None)
tls_client_key(str): filepath for a client key(default:None)
tls_verify(bool): Enable TLS verification(default:False)