### PR TITLE
include build system in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry"]
+build-backend = "poetry.masonry.api"
+
 [tool.black]
 line-length = 88
 target-version = ["py36", "py37", "py38"]


### PR DESCRIPTION
Add a build-system section to pyproject.toml to support installing using `pip install git+https://...`.

According to docs this is added to all new projects anyway.

Reference: https://python-poetry.org/docs/pyproject/#poetry-and-pep-517